### PR TITLE
Add .se .nu and .no TLDs to exception

### DIFF
--- a/Quaratine-SuspiciousCharactersInFromHeader.txt
+++ b/Quaratine-SuspiciousCharactersInFromHeader.txt
@@ -30,5 +30,8 @@ x̣
 == SET1 - BEGIN <TEXT> ==
 
 \.dk$
+\.se$
+\.nu$
+\.no$
 
 == SET1 - END <TEXT> ==


### PR DESCRIPTION
Hai,
As `Å` is used by all the Scandinavian countries I added those TLDs.
I don't know if you also want to add `Ä,Æ,Ö,Ø` but those would also fall under the same TLDs.

Stay Swifty <img src="https://emoji.slack-edge.com/T09K5E2M8/tay/f281b204bc62cd07.png" alt=":tay:" height="32" width="32"/>

_//Carl_